### PR TITLE
Fix pyramid absolute import

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,8 @@ build
 .pytest_cache
 .coverage
 
-
 # emacs backup files
 *~
+
+# Virtual environments
+/venv

--- a/geru/ccdf/pyramid.py
+++ b/geru/ccdf/pyramid.py
@@ -3,10 +3,10 @@
 from pyramid.settings import asbool
 
 
-def includeme(settings):
+def includeme(config):
     import geru.ccdf
-    geru.ccdf.write_key = settings.get_settings().get('geru.ccdf.write_key')
-    geru.ccdf.host = settings.get_settings().get('geru.ccdf.host')
-    geru.ccdf.debug = asbool(settings.get_settings().get('geru.ccdf.debug'))
+    geru.ccdf.write_key = config.get_settings().get('geru.ccdf.write_key')
+    geru.ccdf.host = config.get_settings().get('geru.ccdf.host')
+    geru.ccdf.debug = asbool(config.get_settings().get('geru.ccdf.debug'))
 
-    geru.ccdf.testing = asbool(settings.get_settings().get('geru.ccdf.testing'))
+    geru.ccdf.testing = asbool(config.get_settings().get('geru.ccdf.testing'))

--- a/geru/ccdf/pyramid.py
+++ b/geru/ccdf/pyramid.py
@@ -1,4 +1,7 @@
 """Use pyramid configuration to configure client"""
+from __future__ import absolute_import
+# This file is called `pyramid.py` but is trying to import from a global
+# pyramid package below, so we need absolute imports above on Python 2
 
 from pyramid.settings import asbool
 

--- a/geru/ccdf/test/conftest.py
+++ b/geru/ccdf/test/conftest.py
@@ -1,0 +1,18 @@
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def geru_ccdf_config_cleanup():
+    """ Force clean up module level config after every test.
+
+    Some tests have been polluting geru.ccdf settings and not restoring
+    afterwards.
+
+    So we just clean up after each of them.
+    """
+    import geru.ccdf
+    backup = geru.ccdf.__dict__.copy()
+
+    yield geru.ccdf
+    # restore backup:
+    geru.ccdf.__dict__.update(backup)

--- a/geru/ccdf/test/pyramid_integration.py
+++ b/geru/ccdf/test/pyramid_integration.py
@@ -1,0 +1,23 @@
+
+
+def test_pyramid_integration():
+    import geru.ccdf
+    from pyramid.config import Configurator
+
+    assert geru.ccdf.write_key is None
+    assert geru.ccdf.host is None
+    assert geru.ccdf.debug == False
+    assert geru.ccdf.testing == False
+
+    with Configurator(settings={
+        'geru.ccdf.write_key': 'A write key',
+        'geru.ccdf.host': 'a-host.example.com',
+        'geru.ccdf.debug': 'false',
+        'geru.ccdf.testing': 'true',
+    }) as config:
+        config.include('geru.ccdf.pyramid')
+
+        assert geru.ccdf.write_key == 'A write key'
+        assert geru.ccdf.host == 'a-host.example.com'
+        assert geru.ccdf.debug == False
+        assert geru.ccdf.testing == True

--- a/setup.py
+++ b/setup.py
@@ -31,7 +31,7 @@ test_require = [
 
 setup(
     name='geru.ccdf',
-    version='0.0.4',
+    version='0.0.5',
     url='https://github.com/segmentio/analytics-python',
     author='Segment',
     author_email='friends@segment.com',


### PR DESCRIPTION
The module file called `pyramid.py` was trying to import from `pyramid.settings` but failing because it was doing a relative import of itself.